### PR TITLE
layout: autohide after X seconds since last encounter

### DIFF
--- a/components/layout/settings/10-layout.vue
+++ b/components/layout/settings/10-layout.vue
@@ -61,6 +61,13 @@
       <checkbox
         label="Less information on detailed view"
         v-model="reduced" />
+      <number
+        label="Hide after (sec)"
+        :min="0"
+        :max="60"
+        :step="1"
+        :default="10"
+        v-model="hide_after" />
     </group>
     <group name="Tickers">
       <figure class="tab-content-presentation w-settings-layout-preview">
@@ -247,6 +254,7 @@ export default {
       'yield_for_subtickers',
       'hide_name',
       'hide_job_icon',
+      'hide_after',
       'list_order',
       'list_align',
       'reduced'

--- a/index.vue
+++ b/index.vue
@@ -19,8 +19,8 @@
         'force-singleline-allowed': force_singleline_allowed
       }
     ]">
-    <userlist />
-    <navbar />
+    <userlist v-if="!hidden" />
+    <navbar v-if="!hidden"/>
     <settings v-if="opened_window === 'settings'" />
     <changelog v-if="opened_window === 'changelog'" />
     <layout-mode v-if="layout_mode" />
@@ -69,6 +69,9 @@ export default {
       'opened_window',
       'layout_mode'
     ]),
+    ...mapState('ui', {
+      hidden: state => !state.hideTimeoutId,
+    }),
     ...mapGetters('settings', [
       'force_singleline_allowed'
     ])

--- a/store/encounter.js
+++ b/store/encounter.js
@@ -233,7 +233,7 @@ export default {
   },
   actions: {
     // Listeners
-    update({ commit, rootGetters }, { Encounter, Combatant }) {
+    update({ commit, dispatch, rootGetters }, { Encounter, Combatant }) {
       if(!Encounter || Encounter.hits < 1) {
         return
       }
@@ -242,6 +242,7 @@ export default {
         combatants: Combatant,
         playerNames: rootGetters['settings/usernames']
       })
+      dispatch('ui/show', null, { root: true })
     },
     logline({ commit }, { type, payload }) {
       switch(type) {

--- a/store/settings.js
+++ b/store/settings.js
@@ -14,6 +14,7 @@ const _state = () => ({
   yield_for_subtickers: true,
   hide_name: false,
   hide_job_icon: false,
+  hide_after: 10,
   force_inline_short_values: true,
   reduced: false,
   // appearance

--- a/store/ui.js
+++ b/store/ui.js
@@ -1,4 +1,5 @@
 const _state = () => ({
+  hideTimeoutId: null,
   opened_window: null,
   layout_mode: false
 })
@@ -12,6 +13,14 @@ export default {
     close(state) {
       state.opened_window = null
     },
+    updateHideTimeoutId(state, id) {
+      if(id == null) {
+        state.hideTimeoutId = null
+      } else {
+        clearTimeout(state.hideTimeoutId)
+        state.hideTimeoutId = id
+      }
+    },
     toggleLayoutMode(state, to) {
       if(to === undefined) {
         state.layout_mode = !state.layout_mode
@@ -23,6 +32,12 @@ export default {
   getters: {
   },
   actions: {
+    show({ commit, rootState }) {
+      const timeoutId = setTimeout(() => {
+        commit('updateHideTimeoutId', null)
+      }, rootState.settings.hide_after * 1000)
+      commit('updateHideTimeoutId', timeoutId)
+    }
   },
   namespaced: true
 }


### PR DESCRIPTION
Implements https://github.com/hibiyasleep/ikegami/issues/9.

Note that it isn't 100% accurate and is ~1-2 seconds off, because there is sometimes a trailing encounter update about a second or two after the encounter actually finishes. So setting it to 10 seconds might actually hide it 12 seconds after the encounter "finishes", but that should still be good enough for what I want it for at least. 

I can't base the PR on a tag, only a branch, either v0.3.3 needs to be merged down into `main` or onto its own branch for it to be based properly. 

Published version to test out here: https://anonymousthing.github.io/ikegami/