### PR TITLE
Enable wrapping for Userlist elements

### DIFF
--- a/components/layout/userlist.vue
+++ b/components/layout/userlist.vue
@@ -95,6 +95,7 @@ export default {
   > ul
     display: flex
     max-width: 100%
+    flex-wrap: wrap
 
     align-items: flex-start
     justify-content: flex-start


### PR DESCRIPTION
Enables the ability to dynamically stack Userlist elements, as described in https://github.com/hibiyasleep/ikegami/issues/45#issuecomment-1386059670

Userlist stacking is based on the width of the overlay from layout mode, and does not stack other elements.