### PR TITLE
Always show top players even with descending order

### DIFF
--- a/components/layout/userlist.vue
+++ b/components/layout/userlist.vue
@@ -37,7 +37,7 @@ export default {
 
       if(this.list_order === 'desc') {
         // assuming worst case of combatant count: 124px * 75% * 32 = 2976px
-        return this.$store.state.encounter.combatants.slice(-32).reverse()
+        return this.$store.state.encounter.combatants.slice(0, 32).reverse()
       } else {
         return this.$store.state.encounter.combatants.slice(0, 32)
       }


### PR DESCRIPTION
When `list_order` was set to `desc`, only the lowest 32 players would be rendered in the list which breaks if there are more than (eg. in S-rank hunts).
Imho the code should always use the same slice of top players and just reverse rendering.